### PR TITLE
Include cubes structure in the UMD rybitten global

### DIFF
--- a/src/entryForUMD.ts
+++ b/src/entryForUMD.ts
@@ -1,0 +1,4 @@
+import * as cubes from "./cubes.ts";
+
+export * from "./main.ts";
+export { cubes };

--- a/src/p5.html
+++ b/src/p5.html
@@ -1,47 +1,57 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>p5.js Example</title>
-  <script src="https://unpkg.com/rybitten"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/p5.js"></script>
-</head>
-<body>
-  <script>
-    let i = 0;
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>p5.js Example</title>
+    <!-- <script src="https://unpkg.com/rybitten"></script> -->
+    <script src="../dist/rybitten.umd.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/p5.js"></script>
+  </head>
+  <body>
+    <script>
+      let preferredCube = rybitten.cubes.cubes.get("marvel-news");
 
-    function setup() {
-      createCanvas(400, 400);
-      colorMode(RGB, 1); // rybitten returns RGB values in [0, 1]
-      noStroke();
-    }
-
-    function draw() {
-      i += 1;
-      // Access functions via the global 'rybitten' object
-      colorMode(rybitten.RYB);
-      background(
-        rybitten.ryb2rgb([1, 1, 1])
-      );
-      for (let x = 0; x < 20; x++) {
-        for (let y = 0; y < 20; y++) {
-          fill(
-            rybitten.rybHsl2rgb([
-              (x / 20 * 360 + i) % 360,
-              1,
-              y / 20
-            ])
-          );
-          rect(x * 20, y * 20, 20, 20);
-        }
+      function setup() {
+        createCanvas(400, 400);
+        colorMode(RGB, 1); // rybitten returns RGB values in [0, 1]
+        noStroke();
       }
-      fill(rybitten.ryb2rgb([0, 0, 0]));
-      rect(200 - 50, 200 - 50, 100, 100);
 
-      fill(rybitten.ryb2rgb([1, 1, 1]));
-      rect(200 - 25, 200 - 25, 50, 50);
-    }
-  </script>
-</body>
+      function draw() {
+        // Access functions via the global 'rybitten' object
+        // colorMode(rybitten.RYB);
+        background(rybitten.ryb2rgb([1, 1, 1], preferredCube));
+        for (let x = 0; x < 20; x++) {
+          for (let y = 0; y < 20; y++) {
+            fill(
+              rybitten.rybHsl2rgb(
+                [((x / 20) * 360 + frameCount) % 360, 1, y / 20],
+                preferredCube,
+              ),
+            );
+            rect(x * 20, y * 20, 20, 20);
+          }
+        }
+        fill(rybitten.ryb2rgb([0, 0, 0], preferredCube));
+        rect(200 - 50, 200 - 50, 100, 100);
+
+        fill(rybitten.ryb2rgb([1, 1, 1], preferredCube));
+        rect(200 - 25, 200 - 25, 50, 50);
+
+        drawCubeName();
+      }
+
+      function mousePressed() {
+        preferredCube = random(Array.from(rybitten.cubes.cubes.values()));
+      }
+      function drawCubeName() {
+        push();
+        textAlign(RIGHT, BOTTOM);
+        textSize(16);
+        text(preferredCube.title, width, height);
+        pop();
+      }
+    </script>
+  </body>
 </html>

--- a/vite.config.umd.js
+++ b/vite.config.umd.js
@@ -2,19 +2,19 @@ import { resolve } from "path";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  build: {
-    emptyOutDir: false,
-    lib: {
-      entry: resolve(__dirname, "src/main.ts"),
-      name: "rybitten",
-      formats: ["umd"],
-      fileName: (format) => `rybitten.${format}.js`,
+    build: {
+        emptyOutDir: false,
+        lib: {
+            entry: resolve(__dirname, "src/entryForUMD.ts"),
+            name: "rybitten",
+            formats: ["umd"],
+            fileName: (format) => `rybitten.${format}.js`,
+        },
+        rollupOptions: {
+            output: {
+                entryFileNames: "rybitten.umd.js",
+                exports: "named",
+            },
+        },
     },
-    rollupOptions: {
-      output: {
-        entryFileNames: "rybitten.umd.js",
-        exports: "named",
-      },
-    },
-  },
 });

--- a/vite.config.umd.js
+++ b/vite.config.umd.js
@@ -2,19 +2,19 @@ import { resolve } from "path";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-    build: {
-        emptyOutDir: false,
-        lib: {
-            entry: resolve(__dirname, "src/entryForUMD.ts"),
-            name: "rybitten",
-            formats: ["umd"],
-            fileName: (format) => `rybitten.${format}.js`,
-        },
-        rollupOptions: {
-            output: {
-                entryFileNames: "rybitten.umd.js",
-                exports: "named",
-            },
-        },
+  build: {
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(__dirname, "src/entryForUMD.ts"),
+      name: "rybitten",
+      formats: ["umd"],
+      fileName: (format) => `rybitten.${format}.js`,
     },
+    rollupOptions: {
+      output: {
+        entryFileNames: "rybitten.umd.js",
+        exports: "named",
+      },
+    },
+  },
 });


### PR DESCRIPTION
Hi.  Just an experiment - not expecting you to merge this!

I made the contents of the cubes module available (perhaps they already were - I just couldn't see them in the debugger). 

I extended the p5 demo to allow the user to demo the different cubes by clicking.  That makes it more complex than you'd probably want for a real first use p5 demo, I guess.

*While it works, I have some unwanted doubling in the exported structure that I think I didn't have earlier: needing to write `rybitten.cubes.cubes` to get to the map.

* Also, I pointed p5.html at ../dist/rybitten.umd.js rather than the CDN, just to make it quicker to test this throwaway branch.

* Also, `colorMode(rybitten.RYB)` failed for me (on the *existing* build, I think) because rybitten.RYB seems undefined.  Perhaps I'm mistaken though.